### PR TITLE
Removed sudo requirement

### DIFF
--- a/website.yml
+++ b/website.yml
@@ -1,6 +1,5 @@
 - name: example nginx website
   hosts: web
-  sudo: true
   tasks:
     - name: Start etcd
       service: name=etcd.service state=started


### PR DESCRIPTION
Running these commands as root causes the "pip" command to fail. "pip" is looking for the binaries in "/root", rather that the user's actual home directory, which could be "/home/core".