### PR TITLE
Always use vagrants insecure key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,9 @@ if File.exist?(CONFIG)
 end
 
 Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+  
   config.vm.box = "coreos-%s" % $update_channel
   config.vm.box_version = ">= 308.0.1"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel


### PR DESCRIPTION
Setup vagrant to always use it's insecure key, else vagrant will automatically replace it with a different key and the ssh login (ansible commands) will fail.