### PR TITLE
Fixes Issue 10: mem_limit failure

### DIFF
--- a/website.yml
+++ b/website.yml
@@ -7,7 +7,7 @@
       sudo_user: root
 
     - name: Install docker-py
-      pip: name=docker-py version=0.6.0
+      pip: name=docker-py version=1.2.3
 
     - name: pull container
       raw: docker pull nginx:1.7.1


### PR DESCRIPTION
Previously, website.yml specified docker-py version=0.6.0. This
version has a known issue [1] that causes this problem.

[1] https://github.com/ansible/ansible-modules-core/issues/1707

website.yml has been updated to use docker-py 1.2.3